### PR TITLE
fm-1085/fm-1521

### DIFF
--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/IPRangeSet.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/IPRangeSet.java
@@ -48,7 +48,6 @@ public class IPRangeSet implements Iterable<IPRange>
 				catch (Exception unused)
 				{	/* besides due to invalid strings exceptions might get thrown if the string
 					 * contains a hostname (NetworkOnMainThreadException) */
-					return null;
 				}
 			}
 		}


### PR DESCRIPTION
Fix for:
```
java.lang.NullPointerException: Attempt to read from field 'java.util.TreeSet org.strongswan.android.utils.IPRangeSet.mRanges' on a null object reference
	at org.strongswan.android.utils.IPRangeSet.remove(IPRangeSet.java:147)
	at org.strongswan.android.logic.CharonVpnService$BuilderCache.applyData(CharonVpnService.java:1303)
	at org.strongswan.android.logic.CharonVpnService$BuilderAdapter.establishIntern(CharonVpnService.java:960)
	at org.strongswan.android.logic.CharonVpnService$BuilderAdapter.establishBlocking(CharonVpnService.java:1003)
	at org.strongswan.android.logic.CharonVpnService.stopCurrentConnection(CharonVpnService.java:355)
	at org.strongswan.android.logic.CharonVpnService.run(CharonVpnService.java:269)
```